### PR TITLE
Make compatible with normally installed concrete5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "concrete5-package",
     "license": "MIT",
     "minimum-stability": "stable",
-    "require": {
+    "require-dev": {
         "concrete5/core": "^8.2"
     },
     "autoload": {

--- a/controller.php
+++ b/controller.php
@@ -16,11 +16,25 @@ class Controller extends Package
 
     public function on_start()
     {
+        $this->registerAutoload();
+
         // Extend the ServerInterface binding so that when concrete5 creates the http server we can add our middleware
         $this->app->extend(ServerInterface::class, function(ServerInterface $server) {
             // Add our custom middleware
             $server->addMiddleware($this->app->make(Middleware::class));
         });
+    }
+
+    /**
+     * We use composer.json to load custom codes instead of $pkgAutoloaderRegistries in this package.
+     * This method is not required when you install concrete5 core via composer,
+     * just for compatibility for normally installed concrete5.
+     */
+    public function registerAutoload()
+    {
+        if (file_exists($this->getPackagePath().'/vendor/autoload.php')) {
+            require $this->getPackagePath().'/vendor/autoload.php';
+        }
     }
 
 }


### PR DESCRIPTION
This sample package is very interested, but it doesn't have compatibility with normally installed concrete5. This pull request makes this package works on both of old style and composer style.

* Require autoload.php in package directory if it exists
* Move `concrete5/core` to `require-dev` section. Now we can run `composer install —no-dev` in this directory

_I'm not good at english grammar, so please fix the comment._